### PR TITLE
Added travis to repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: ruby
 cache: bundler
 script: bundle exec rspec tests/
+deploy:
+  provider: releases
+  api_key:
+    secure: dprQqh0dR6IX7dpT4+VZn9JiDgKSb+TwXomQXSchR2biEjjAFlqWF5sJBxjJW+DQlUIgAA5AwBhQ6ZHA03ez7CcEgFCRq0KiIZqLWrdCZXConyxG1o74H2VHrFB5BPML3OVlCCZSO21pNwi4DsZNI+IplV81bMYS3li1+9ULCN0az9i49r2DEavE4scCJIAu5CDuTO1y62fXT7q5z0EMAPxBeknHOiwF1ME9fNlF1wpzb0sSyTtfoA4bPHQFbR9W6RLgKXatUC25Cqb1l1ooXCUMFj9wVa3y1rRMsX3Tq0MsRPy3Qxfa6kZw5Lm6MDZiRfvNG3tVDihC4YANC9Vz8vHqXSaGiQ1Bt6P2NXWzFiekRevcVnn5FIYhw5k5mSGnt0dze/a5UB2vyhwY/n1CasFGr9FGLrZgxLedHzK5kiFLFIB6KGVXez5zNs2AjT54g6Ryf3+rvS1UY2HW9y1AO/98kqobUcqcm1DsCTE2/PAq4W1GADrPNWH26kQ9gEMABs4UIv1r5KJz86DRC/1BB8BVBFWKsGg1vbSX/5xloClhHyrExwsT4s3yW5ta/F25Q8+d08kQ69eiW8kAkX+EL0JaKfIYGtqoqMi56p6/h9yaHcKW9ZYl5UlIrmG2j4xhjVNErBm8Jbrwkvszkch3Bep3BKkAriF2ivDqUWbHsoA=
+  file: bofrev.jar
+  skip_cleanup: true
+  before_deploy: "make_jar"
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+cache: bundler
+script: bundle exec rspec tests/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bofrev
 
+[![Build Status](https://travis-ci.org/panmari/bofrev.svg?branch=master)](https://travis-ci.org/panmari/bofrev)
+
 **bofrev** - Boring Friday Evening - originates from a Friday late-night coding session.
 
 The idea behind this project _is_ to implement a _Framework_ to

--- a/tests/grid_spec.rb
+++ b/tests/grid_spec.rb
@@ -1,6 +1,4 @@
-require_relative '../src/grid'
-require_relative '../src/color'
-require 'pry'
+require_relative 'spec_helpers'
 
 describe Grid do
 
@@ -10,7 +8,7 @@ describe Grid do
   end
 
   it 'should have total width of M+2 and total height of N+2' do
-    m = 13; n = 22;
+    m = 13; n = 22
     grid = Grid.new(m, n)
     expect(grid.inner_width).to eq(m)
     expect(grid.inner_height).to eq(n)

--- a/tests/point2f_spec.rb
+++ b/tests/point2f_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../src/point2f'
+require_relative 'spec_helpers'
 
 describe Point2f do
   it 'shoud instantiate a (0,0) value when passing no args' do

--- a/tests/spec_helpers.rb
+++ b/tests/spec_helpers.rb
@@ -1,0 +1,3 @@
+# Add lib folder to load path.
+$LOAD_PATH.unshift File.expand_path("src")
+require "application"


### PR DESCRIPTION
To enhance/enforce test coverage, I added travis-ci support to the repository. The owner of the repository (@simplay) still needs to enable support for the repository on https://travis-ci.org/.

Also adapted tests to run on travis.

The links on line this line: https://github.com/simplay/bofrev/compare/master...panmari:master#diff-04c6e90faac2675aa89e2176d2eec7d8R3 will have to be adapted to the main repository.

In a further step, we'll be able to make even releases on github using travis, enabling us to remove the ugly comitted binary from the repository.
