### PR TITLE
Fixes generating jars when running make_jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This project is licensed under the [MIT License](https://github.com/simplay/bofr
 
 + All sound files are from [freesound.org](www.freesound.org).
 + For playing sound files, bofrev uses the java library [TinySound](https://github.com/finnkuusisto/TinySound).
++ For generating an exectuable bofrev jar file we make use of [Warble](https://github.com/jruby/warbler).
+
 
 ## Features
 

--- a/bofrev
+++ b/bofrev
@@ -43,6 +43,14 @@ rescue OptionParser::MissingArgument
   exit
 end
 
+# is bofrev runned by jar or by console
+caller_name = "#{$PROGRAM_NAME}"
+if caller_name.include?("<script>")
+  $audio_files_base_path = "bofrev/"
+else
+  $audio_files_base_path = ""
+end
+puts "runned by #{$audio_files_base_path}"
 Application.new(user_args)
 
 

--- a/config/warble.rb
+++ b/config/warble.rb
@@ -8,7 +8,7 @@ Warbler::Config.new do |config|
   # - gemjar: package the gem repository in a jar file in WEB-INF/lib
   # - executable: embed a web server and make the war executable
   # - compiled: compile .rb files to .class files
-  # config.features = %w(gemjar)
+  config.features = %w(executable)
 
   # Application directories to be included in the webapp.
   #config.dirs = %w(audio/jump.wav, bofrev)
@@ -23,8 +23,8 @@ Warbler::Config.new do |config|
   # in lib (and not otherwise excluded) then they need not be mentioned here.
   # JRuby and JRuby-Rack are pre-loaded in this list.  Be sure to include your
   # own versions if you directly set the value
-  config.java_libs += FileList["lib/tinysound-1.1.1/tinysound-1.1.1.jar"]
-  config.java_libs += FileList["lib/tinysound-1.1.1/lib/jorbis-0.0.17.jar",
+  config.java_libs += FileList["lib/tinysound-1.1.1/tinysound-1.1.1.jar",
+                               "lib/tinysound-1.1.1/lib/jorbis-0.0.17.jar",
                                "lib/tinysound-1.1.1/lib/tritonus_share.jar",
                                "lib/tinysound-1.1.1/lib/vorbisspi1.0.3.jar"]
 #, lib/tinysound-1.1.1/lib/orbis-0.0.17.jar, lib/tinysound-1.1.1/lib/ritonus_share.jar, lib/tinysound-1.1.1/lib/orbisspi1.0.3.jar

--- a/src/java_music_player.rb
+++ b/src/java_music_player.rb
@@ -10,6 +10,7 @@ class JavaMusicPlayer
 
 
   def initialize(file)
+    return if file.nil?
     @file = $audio_files_base_path+file
     @is_runnable = true
     TinySound.init

--- a/src/java_music_player.rb
+++ b/src/java_music_player.rb
@@ -10,7 +10,7 @@ class JavaMusicPlayer
 
 
   def initialize(file)
-    @file = file
+    @file = $audio_files_base_path+file
     @is_runnable = true
     TinySound.init
   end


### PR DESCRIPTION
Addresses Issue #35 

Fixes generating bofrev exectuable jar files. After changing the sound library (in Pr #33) sound files were no longer played, when running the bofrev.jar executable. This PR fixes this issue.

The problem occured due to incorrect pathing. Within bofrev.jar, the filehierarchy is slightly different than given by the project (since warble is made for rails and other webapps - we are exploiting this gem :D ).
Therefore, during runtime, depending whether we are running the jar or executing bofrev via jruby, we have to adapt the paths accordingly.

**update**: The latest generated bofrev.jar seems to work on mac os x, windows 7 and ubuntu 14.04.
