### PR TITLE
Handle system specific Settings

### DIFF
--- a/bofrev
+++ b/bofrev
@@ -43,14 +43,4 @@ rescue OptionParser::MissingArgument
   exit
 end
 
-# is bofrev runned by jar or by console
-caller_name = "#{$PROGRAM_NAME}"
-if caller_name.include?("<script>")
-  $audio_files_base_path = "bofrev/"
-else
-  $audio_files_base_path = ""
-end
-puts "runned by #{$audio_files_base_path}"
 Application.new(user_args)
-
-

--- a/src/game_settings.rb
+++ b/src/game_settings.rb
@@ -1,4 +1,5 @@
 require 'game_meta_data'
+require 'system_information'
 require_relative 'apps/tetris/tetris_meta_data'
 require_relative 'apps/game_of_life/game_of_life_meta_data'
 require_relative 'apps/sokoban/sokoban_meta_data'
@@ -144,4 +145,17 @@ class GameSettings
     grid_is_shown = GameSettings.render_attributes[:show_grid]
     grid_is_shown.nil? ? true : grid_is_shown
   end
+
+  # Get top level folder name where the audio folder lies in.
+  #
+  # @hint: In case bofrev is called by its executable jar, there is an additional
+  # namespace folder called 'bofrev'. Every folder of the bofrev folder is put into
+  # this parent folder by the jar. When running bofrev from the code, there is no such parent
+  # folder. This is why we return for this case the prefix ''.
+  #
+  # @return [String] 'bofrev/' if bofrev.jar is called and '' otherwise.
+  def self.audio_filefolder_prefix
+    SystemInformation.called_by_jar? ? 'bofrev/' : ''
+  end
+
 end

--- a/src/game_settings.rb
+++ b/src/game_settings.rb
@@ -158,4 +158,22 @@ class GameSettings
     SystemInformation.called_by_jar? ? 'bofrev/' : ''
   end
 
+  # return [Array] including canvas offsets for packing into main_frame.
+  def self.canvas_offsets
+    offset_x = 1
+    offset_y = 45
+    if SystemInformation.running_on_windows?
+      offset_x = 6
+    end
+    [offset_x, offset_y]
+  end
+
+  def self.canvas_width
+    canvas_offsets[0] + max_width
+  end
+
+  def self.canvas_height
+    canvas_offsets[1] + max_height
+  end
+
 end

--- a/src/java_music_player.rb
+++ b/src/java_music_player.rb
@@ -1,3 +1,4 @@
+require 'game_settings'
 require 'java'
 java_import "java.io.FileInputStream"
 
@@ -11,7 +12,7 @@ class JavaMusicPlayer
 
   def initialize(file)
     return if file.nil?
-    @file = $audio_files_base_path+file
+    @file = GameSettings.audio_filefolder_prefix+file
     @is_runnable = true
     TinySound.init
   end

--- a/src/java_music_player.rb
+++ b/src/java_music_player.rb
@@ -1,6 +1,5 @@
 require 'game_settings'
 require 'java'
-java_import "java.io.FileInputStream"
 
 require_relative '../lib/tinysound-1.1.1/tinysound-1.1.1.jar'
 java_import 'kuusisto.tinysound.Music'
@@ -8,7 +7,6 @@ java_import 'kuusisto.tinysound.Sound'
 java_import 'kuusisto.tinysound.TinySound'
 
 class JavaMusicPlayer
-
 
   def initialize(file)
     return if file.nil?

--- a/src/main_frame.rb
+++ b/src/main_frame.rb
@@ -17,14 +17,8 @@ class MainFrame < JFrame
 
   def initialize(game)
     super("GAME")
-    @offset_x = 1
-    @offset_y = 45
     @game = game
     init_gui
-  end
-
-  def offsets
-    [@offset_x, @offset_y]
   end
 
   def update_canvas
@@ -48,7 +42,7 @@ class MainFrame < JFrame
     @canvas.game = @game
     container.add(@canvas, BorderLayout::CENTER)
     setDefaultCloseOperation(JFrame::EXIT_ON_CLOSE)
-    setMinimumSize(Dimension.new(GameSettings.max_width+@offset_x, GameSettings.max_height+@offset_y))
+    setMinimumSize(Dimension.new(GameSettings.canvas_width, GameSettings.canvas_height))
     controls = JPanel.new
     controls.setLayout(FlowLayout.new(FlowLayout::CENTER))
     container.add(controls, BorderLayout::PAGE_END)

--- a/src/system_information.rb
+++ b/src/system_information.rb
@@ -25,6 +25,10 @@ class SystemInformation
     build.os.include?('windows')
   end
 
+  def self.running_on_linux?
+    build.os.include?('linux')
+  end
+
   def self.called_by_jar?
     build.caller == CALLER_JAR
   end

--- a/src/system_information.rb
+++ b/src/system_information.rb
@@ -1,0 +1,49 @@
+require 'java'
+java_import 'java.lang.System'
+
+# SystemInformation provides runtime information such as on which os bofrev is running
+# or by whom it is called (either from the console or by an exectuable jar).
+# This kind of system information will be used to handle os/system specific circumstances
+# that affect the runtime behaviour of bofrev. For example, on windows there is a different
+# offset for the canvas required (since unit pixels seem be differently sized than on other os).
+# Another example is the case when bofrev is called by its exectuable jar.
+# Then the whole pathing has to be differently handled (otherwise music/image files
+# will not be loaded correctly). This is due to the fact that
+# the jar has a different file hierarchy.
+class SystemInformation
+
+  attr_reader :os, :caller
+
+  CALLER_JAR = 'jar'
+  CALLER_CONSOLE = 'console'
+
+  def self.running_on_mac?
+    build.os.include?('mac')
+  end
+
+  def self.running_on_windows?
+    build.os.include?('windows')
+  end
+
+  def self.called_by_jar?
+    build.caller == CALLER_JAR
+  end
+
+  def self.called_by_console?
+    build.caller == CALLER_CONSOLE
+  end
+
+  private
+
+  def self.build
+    return @system_information unless @system_information.nil?
+    @system_information = SystemInformation.new
+  end
+
+  def initialize
+    caller_name = "#{$PROGRAM_NAME}"
+    @caller = caller_name.include?("<script>") ? CALLER_JAR : CALLER_CONSOLE
+    @os = System.getProperty("os.name").downcase
+  end
+
+end

--- a/src/view.rb
+++ b/src/view.rb
@@ -43,7 +43,7 @@ class View < Observer
 
     @main_frame.add_mouse_motion_listener MouseMotionListener.impl { |name, event|
       # key_debugger("MouseMotionListener", name, event)
-      offsets = @main_frame.offsets
+      offsets = GameSettings.canvas_offsets
       x = event.getX-offsets[0]/2
       y = event.getY-offsets[1]/2
       event_identifier = "#{name}_#{event.get_button}"
@@ -52,7 +52,7 @@ class View < Observer
 
     @main_frame.add_mouse_listener MouseListener.impl { |name, event|
       # key_debugger("MouseListener", name, event)
-      offsets = @main_frame.offsets
+      offsets = GameSettings.canvas_offsets
       x = event.getX-offsets[0]/2
       y = event.getY-offsets[1]/2
       event_identifier = "#{name}_#{event.get_button}"


### PR DESCRIPTION
Introduced a SystemInformation singleton that knows on which os bofrev is running and whether bofrev was called by its jar or by the console (i.e. the code was exectuted).
The GameSetting singleton makes use of SystemInformation to adapt its settings accordingly. All relevant properties are defined in GameSettings. There are no global variables required anymore.

Addresses Issue #37 

A list of available os names can be found [here](http://mindprod.com/jgloss/properties.html#OSNAME).

Tested this PR on windows, mac os x and ubuntu 14.04 and it seems to work.
