### PR TITLE
Cleanup Testing Env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 jdk: oraclejdk8
 before_install: gem install bundler
-install: gem install codeclimate-test-reporter; gem install coveralls
+install: bundle install --without development --deployment --jobs=3 --retry=3
 cache: bundler
 addons:
   code_climate:
     repo_token: 138d988c6c17e0b334291d26c852330a9212bdd3eaf0fd6cb5e524585e655a71
 script: rake test:coverage
-after_success: coveralls
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 jdk: oraclejdk8
-before_install: gem install bundler
+rvm: jruby-9.0.1.0
+before_install: gem install bundler; gem install codeclimate-test-reporter; gem install coveralls
 install: bundle install --without development --deployment --jobs=3 --retry=3
 cache: bundler
 addons:

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gem 'minitest'
 gem 'inch', require: false
 
 # for keeping track of test coverage
-gem 'simplecov', :require => false
-gem 'coveralls', :require => false
-gem "codeclimate-test-reporter", group: :test, require: nil
+gem 'simplecov'
+gem 'coveralls'
+gem "codeclimate-test-reporter"

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,9 @@ gem 'inch', require: false
 
 # for keeping track of test coverage
 gem 'simplecov', require: false
+
+# for generating coverage report
 gem 'coveralls', require: false
+
+# for reporting coverage report to code climate
 gem "codeclimate-test-reporter", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gem 'minitest'
 gem 'inch', require: false
 
 # for keeping track of test coverage
-gem 'simplecov'
-gem 'coveralls'
-gem "codeclimate-test-reporter"
+gem 'simplecov', require: false
+gem 'coveralls', require: false
+gem "codeclimate-test-reporter", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
+# Default task is running rake test (without coverage)
 task :default => :test
+
+# Run all tests and require all necessary files
 task :test do
   require 'java'
   $LOAD_PATH.unshift File.expand_path("src")
@@ -12,6 +15,7 @@ task :test do
   end
 end
 
+# run all test in test/ and also run SimpleCov to obtain coverage rate.
 namespace :test do
   task :coverage do
     require 'simplecov'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,17 +1,11 @@
-#if ENV['COVERAGE']
- # require 'simplecov'
- # SimpleCov.start do
- #   add_filter 'test'
- #   command_name 'test'
- # end
-#end
+# necessary requirements for code coverage and reporting its rate.
 require "codeclimate-test-reporter"
 require 'coveralls'
+
+# report coverage (Coveralls.wear! helps us to transmit correct coverage to CodeClimate)
 Coveralls.wear!
-#CodeClimate::TestReporter.configure do |config|
-#  config.path_prefix = "../src/"
-#end 
 CodeClimate::TestReporter.start
 
+# necessary requirements for for minitest
 require 'simplecov'
 require 'minitest/autorun'


### PR DESCRIPTION
JRuby-9.0.1.0 is currently not available for travis in a precompiled form. This is why travis takes ages to to run. Nevertheless, this PR cleans up the latests changes regarding the testing env. and the travis config. 
