### PR TITLE
Define testing utils at a common module

### DIFF
--- a/test/class_adaptions.rb
+++ b/test/class_adaptions.rb
@@ -1,17 +1,5 @@
 module ClassAdaptions
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
   LayerManager.class_eval do
     def layers
       @layers
@@ -71,6 +59,24 @@ module ClassAdaptions
     end
 
     def handle_user_input_notification_for(msg)
+    end
+  end
+
+  # overwridden View class initializer to not spawn a atw frame.
+  View.class_eval do
+    def initialize(game)
+    end
+  end
+
+  Server.class_eval do
+    def initialize
+      puts "server is running"
+    end
+  end
+
+  Client.class_eval do
+    def initialize
+      puts "client is running"
     end
   end
 

--- a/test/class_adaptions.rb
+++ b/test/class_adaptions.rb
@@ -1,3 +1,26 @@
+# ClassAdaptions is a set of class adaptions used during
+# the testing process. Some methods of some classes need
+# an adaption of their behavior in order to make them testable.
+#
+# @hint: when testing View, Canvas classes, we don't want
+#   to span a gui. Especially travis hates such a behavior.
+#   Furthermore, threading has to be simulated.
+# @info: This reduced unknown side effects. applying :class_eval
+#   in different tests on the same target class results
+#   in having unknown side effects.
+# @example: Assume bofrev defines a class Socks that has a method
+#   :wash defining an appropriate behaviour
+#   (unuseful for testing). Then, in order to test this method
+#   modify this class' method such that it is testable. In
+#   the following an example how such a modification is supposed
+#   to look like:
+#
+#     Socks.class_eval do
+#       def wash
+#         # do something meaningful and testable
+#         # mocking the previous washing behavior.
+#       end
+#
 module ClassAdaptions
 
   LayerManager.class_eval do

--- a/test/class_adaptions.rb
+++ b/test/class_adaptions.rb
@@ -1,0 +1,77 @@
+module ClassAdaptions
+
+  # allow to fetch puts outputs
+  def fetch_stdout(&block)
+    begin
+      old_stdout = $stdout
+      $stdout = StringIO.new('','w')
+      yield block
+      $stdout.string
+    ensure
+      $stdout = old_stdout
+    end
+  end
+
+  LayerManager.class_eval do
+    def layers
+      @layers
+    end
+  end
+
+  Layer.class_eval do
+    def drawables
+      @drawables
+    end
+
+    def state
+      @state
+    end
+
+    def update_drawables
+      @state = "update #{self.object_id}"
+    end
+
+    def draw_drawables_onto(g)
+      @state = "draw #{self.object_id}"
+    end
+  end
+
+  Game.class_eval do
+    def music_thread
+      @music_thread
+    end
+
+    def score
+      @score
+    end
+
+    def notify_all_targets_of_type(type)
+    end
+
+  end
+
+  MusicPlayer.class_eval do
+    def play
+    end
+
+    def shut_down
+    end
+  end
+
+  Ticker.class_eval do
+    def start
+    end
+
+    def shut_down
+    end
+  end
+
+  Map.class_eval do
+    def handle_ticker_notification
+    end
+
+    def handle_user_input_notification_for(msg)
+    end
+  end
+
+end

--- a/test/class_adaptions.rb
+++ b/test/class_adaptions.rb
@@ -35,7 +35,6 @@ module ClassAdaptions
 
     def notify_all_targets_of_type(type)
     end
-
   end
 
   MusicPlayer.class_eval do
@@ -77,6 +76,22 @@ module ClassAdaptions
   Client.class_eval do
     def initialize
       puts "client is running"
+    end
+  end
+
+  # locally extend StystemInformation class such that different
+  # caller cases and os environments can be mocked
+  # by setting appropriate fields.
+  SystemInformation.class_eval do
+
+    # fake a target os by setting its fetched field.
+    def set_os(os_name)
+      @os = os_name
+    end
+
+    # fake a target caller by setting its fetched field.
+    def set_caller(caller_name)
+      @caller = caller_name
     end
   end
 

--- a/test/dummy_classes.rb
+++ b/test/dummy_classes.rb
@@ -1,0 +1,94 @@
+module DummyClasses
+
+  # @info is used by:
+  #   TestCanvas
+  class ACanvas < Canvas
+    def public_scope_draw(g)
+      drawing_methods(g)
+    end
+  end
+
+  # @info is used by:
+  #   TestGameMetaData
+  class FancyView; end
+
+  # @info is used by:
+  #   TestGameMetaData
+  class FancyAchievementSystem
+    def initialize; end
+
+    def self.instance
+      FancyAchievementSystem.new
+    end
+  end
+
+  # @info is used by:
+  #   TestGameMetaData
+  class ANewMetaDataGame
+    extend GameMetaData
+  end
+
+  # @info is used by:
+  #   TestGameMetaData
+  class BNewMetaDataGame
+    extend GameMetaData
+
+    def self.gui_type
+      FancyView
+    end
+
+    def self.achievement_system
+      FancyAchievementSystem.instance
+    end
+  end
+
+  # @info is used by:
+  #   TestLayer
+  class ANewDrawableL
+    def initialize(id="")
+      @id = id
+      @state = "init"
+    end
+
+    def drawable?
+      true
+    end
+
+    def state
+      @state
+    end
+
+    def id
+      @id
+    end
+
+    def update_animation_state
+      @state = "#{id}"
+    end
+
+    def draw_onto(g)
+      @state = "drawing #{id}"
+    end
+  end
+
+  # @info is used by:
+  #   TestObserver
+  class ADrawable; end
+
+  # @info is used by:
+  #   TestObserver
+  class ARandomClass < Observer; end
+
+  # @info is used by:
+  #   TestObserver
+  class BRandomClass < Observer
+    def handle_event
+      puts "implemented 1"
+    end
+
+    def handle_event_with(message)
+      puts "implemented 2"
+    end
+  end
+
+end

--- a/test/dummy_classes.rb
+++ b/test/dummy_classes.rb
@@ -1,3 +1,16 @@
+# DummyClasses is a set of classes defined only within the testing environment
+# used for testing. E.g used for testing whether extending/including modules
+# in a class worked as expected. Having all these dummy classes at one common
+# place reduces code duplication and the risk of potential side effects when
+# defining in two different test classes a dumming class having the same name,
+# with a method having the same name but a different implementation.
+#
+# @example: How a new dummy class is supposed to look like:
+#
+#   # @info is used by
+#   # MENTION HERE IN WHICH TEST CLASS THIS DUMMY IS USED
+#   class ANewDummy
+#
 module DummyClasses
 
   # @info is used by:

--- a/test/helper_methods.rb
+++ b/test/helper_methods.rb
@@ -1,4 +1,6 @@
+# HelperMethods is a set of shared helper methods that can be used by all tests.
 module HelperMethods
+
   # allow to fetch puts outputs
   def fetch_stdout(&block)
     begin

--- a/test/helper_methods.rb
+++ b/test/helper_methods.rb
@@ -1,0 +1,13 @@
+module HelperMethods
+  # allow to fetch puts outputs
+  def fetch_stdout(&block)
+    begin
+      old_stdout = $stdout
+      $stdout = StringIO.new('','w')
+      yield block
+      $stdout.string
+    ensure
+      $stdout = old_stdout
+    end
+  end
+end

--- a/test/test_application.rb
+++ b/test/test_application.rb
@@ -4,36 +4,6 @@ require 'observer'
 
 class TestApplication < Minitest::Test
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
-  # overwridden View class initializer to not spawn a atw frame.
-  View.class_eval do
-    def initialize(game)
-    end
-  end
-
-  Server.class_eval do
-    def initialize
-      puts "server is running"
-    end
-  end
-
-  Client.class_eval do
-    def initialize
-      puts "client is running"
-    end
-  end
-
   def test_handle_event
     app = Application.new({})
     out = fetch_stdout {app.handle_event}

--- a/test/test_canvas.rb
+++ b/test/test_canvas.rb
@@ -3,12 +3,6 @@ java_import 'javax.swing.JPanel'
 
 class TestCanvas < Minitest::Test
 
-  class ACanvas < Canvas
-    def public_scope_draw(g)
-      drawing_methods(g)
-    end
-  end
-
   def test_initialize
     canvas = Canvas.new
     background_color = canvas.get_background

--- a/test/test_color.rb
+++ b/test/test_color.rb
@@ -48,7 +48,21 @@ class TestColor < Minitest::Test
   def test_equality
      assert_equal(@random_color == @random_color, true)
      assert_equal(@random_color == Color.new(@random_24_bit_rgb_value), true)
-     rgb_as_i = [@green_channel_i, @red_channel_i, @blue_channel_i]
+     green_i = @green_channel_i
+
+     # make sure that color values differ and are in range [17,255]
+     if @green_channel_i==@red_channel_i
+       if @green_channel_i == 17
+         green_i = 18
+       elsif @green_channel_i == 255
+         green_i = 254
+       else
+          t = @green_channel_i / 2
+          t = 17 if t < 17
+          green_i = t
+       end
+     end
+     rgb_as_i = [green_i, @red_channel_i, @blue_channel_i]
      other_24_bit_rgb_value = "#"+(rgb_as_i.map {|chan| chan.to_s(16)}).join
      assert_equal(@random_color == Color.new(other_24_bit_rgb_value), false)
   end

--- a/test/test_game.rb
+++ b/test/test_game.rb
@@ -3,58 +3,12 @@ require 'event'
 
 class TestGame < Minitest::Test
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
   def setup
     GameSettings.build_from
-    Game.class_eval do
-      def music_thread
-        @music_thread
-      end
+  end
 
-      def score
-        @score
-      end
-
-      def notify_all_targets_of_type(type)
-      end
-
-    end
-
-    MusicPlayer.class_eval do
-      def play
-      end
-
-      def shut_down
-      end
-    end
-
-    Ticker.class_eval do
-      def start
-      end
-
-      def shut_down
-      end
-    end
-
-    Map.class_eval do
-      def handle_ticker_notification
-      end
-
-      def handle_user_input_notification_for(msg)
-      end
-    end
-
+  def before_teardown
+    GameSettings.flush
   end
 
   def test_initialize

--- a/test/test_game_meta_data.rb
+++ b/test/test_game_meta_data.rb
@@ -1,30 +1,6 @@
 require "test_helper"
 
 class TestGameMetaData < Minitest::Test
-  class FancyView; end
-  class FancyAchievementSystem
-    def initialize; end
-
-    def self.instance
-      FancyAchievementSystem.new
-    end
-  end
-
-  class ANewMetaDataGame
-    extend GameMetaData
-  end
-
-  class BNewMetaDataGame
-    extend GameMetaData
-
-    def self.gui_type
-      FancyView
-    end
-
-    def self.achievement_system
-      FancyAchievementSystem.instance
-    end
-  end
 
   def test_extending_works_as_expected
     assert_raises(RuntimeError, "not implemented yet"){ANewMetaDataGame.theme_list}

--- a/test/test_game_settings.rb
+++ b/test/test_game_settings.rb
@@ -237,6 +237,7 @@ class TestGameSettings < Minitest::Test
   end
 
   def test_show_grid_false_case_dont_show
+    GameSettings.flush
     rand_game_settings = GameSettings.build_from({:game => 7})
     assert_equal(GameSettings.show_grid?, false)
   end

--- a/test/test_game_settings.rb
+++ b/test/test_game_settings.rb
@@ -100,6 +100,7 @@ class TestGameSettings < Minitest::Test
   end
 
   def test_music_thread_not_running_when_no_themes
+    GameSettings.flush
     GameSettings.build_from({:game => 5})
     assert_equal(GameSettings.run_music?, false)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,7 @@ CodeClimate::TestReporter.start
 require 'simplecov'
 require 'minitest/autorun'
 require 'class_adaptions'
+require 'helper_methods'
+
 include ClassAdaptions
+include HelperMethods

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,3 +9,5 @@ CodeClimate::TestReporter.start
 # necessary requirements for for minitest
 require 'simplecov'
 require 'minitest/autorun'
+require 'class_adaptions'
+include ClassAdaptions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,9 @@ require 'simplecov'
 require 'minitest/autorun'
 require 'class_adaptions'
 require 'helper_methods'
+require 'dummy_classes'
 
+# Auxiliary testing modules
 include ClassAdaptions
 include HelperMethods
+include DummyClasses

--- a/test/test_layer.rb
+++ b/test/test_layer.rb
@@ -2,18 +2,6 @@ require "test_helper"
 
 class TestLayer < Minitest::Test
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
   class ANewDrawableL
     def initialize(id="")
       @id = id

--- a/test/test_layer.rb
+++ b/test/test_layer.rb
@@ -2,34 +2,6 @@ require "test_helper"
 
 class TestLayer < Minitest::Test
 
-  class ANewDrawableL
-    def initialize(id="")
-      @id = id
-      @state = "init"
-    end
-
-    def drawable?
-      true
-    end
-
-    def state
-      @state
-    end
-
-    def id
-      @id
-    end
-
-    def update_animation_state
-      @state = "#{id}"
-    end
-
-    def draw_onto(g)
-      @state = "drawing #{id}"
-    end
-
-  end
-
   def test_initialize
     assert_equal(Layer.new.drawables, [])
   end

--- a/test/test_layer_manager.rb
+++ b/test/test_layer_manager.rb
@@ -2,46 +2,7 @@ require "test_helper"
 require 'layer'
 class TestLayerManager < Minitest::Test
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
   class ADrawable
-  end
-
-  def setup
-    LayerManager.class_eval do
-      def layers
-        @layers
-      end
-    end
-
-    Layer.class_eval do
-      def drawables
-        @drawables
-      end
-
-      def state
-        @state
-      end
-
-      def update_drawables
-        @state = "update #{self.object_id}"
-      end
-
-      def draw_drawables_onto(g)
-        @state = "draw #{self.object_id}"
-      end
-
-    end
   end
 
   def test_initialize

--- a/test/test_layer_manager.rb
+++ b/test/test_layer_manager.rb
@@ -2,9 +2,6 @@ require "test_helper"
 require 'layer'
 class TestLayerManager < Minitest::Test
 
-  class ADrawable
-  end
-
   def test_initialize
     lm = LayerManager.new
     assert_equal(lm.layers.count, 3)

--- a/test/test_observer.rb
+++ b/test/test_observer.rb
@@ -8,18 +8,6 @@ class TestObserver < Minitest::Test
   class BRandomClass < Observer
   end
 
-  # allow to fetch puts outputs
-  def fetch_stdout(&block)
-    begin
-      old_stdout = $stdout
-      $stdout = StringIO.new('','w')
-      yield block
-      $stdout.string
-    ensure
-      $stdout = old_stdout
-    end
-  end
-
   def test_properly_inherited
     arc = ARandomClass.new
     assert_respond_to(arc, :handle_event)

--- a/test/test_observer.rb
+++ b/test/test_observer.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 class TestObserver < Minitest::Test
 
-  class ARandomClass < Observer
-  end
-
-  class BRandomClass < Observer
-  end
-
   def test_properly_inherited
     arc = ARandomClass.new
     assert_respond_to(arc, :handle_event)
@@ -17,16 +11,6 @@ class TestObserver < Minitest::Test
   end
 
   def test_implementing_abstract_methods_works
-    BRandomClass.class_eval do
-
-      def handle_event
-        puts "implemented 1"
-      end
-
-      def handle_event_with(message)
-        puts "implemented 2"
-      end
-    end
     arc = BRandomClass.new
     out1 = fetch_stdout {arc.handle_event}
     out2 = fetch_stdout {arc.handle_event_with(nil)}

--- a/test/test_system_information.rb
+++ b/test/test_system_information.rb
@@ -8,24 +8,6 @@ class TestSystemInformation < Minitest::Test
     SystemInformation.build
   end
 
-  def setup
-    # locally extend StystemInformation class such that different
-    # caller cases and os environments can be mocked by setting appropriate fields.
-    SystemInformation.class_eval do
-
-      # fake a target os by setting its fetched field.
-      def set_os(os_name)
-        @os = os_name
-      end
-
-      # fake a target caller by setting its fetched field.
-      def set_caller(caller_name)
-        @caller = caller_name
-      end
-
-    end
-  end
-
   def test_running_on_os_methods_windows_case
     SystemInformation.build.set_os("windows")
     assert_equal(SystemInformation.running_on_windows?, true)


### PR DESCRIPTION
Introduce relevant auxiliary modules for consistent testing.

Partially dddresses Issue #46. 

In this PR I introduced the following 3 helper modules:
- **DummyClasses**: Define all dummy classes that will be used for testing. Here again, this reduces code duplication issues.
- **ClassAdaptions**: Define all class_eval statements here. Some methods of some classes need an adaption of their behavior in order to make them testable. For example, when testing View, Canvas classes, we don't want to span a gui. Especially travis hates such a behavior. Furthermore, threading has to be simulated. This reduced unknown side effects. applying class_eval in different tests on the same target class results in having unknown side effects.
- **HelperMethods**: Define all shared helper function here. Reduces code duplications 
