### PR TITLE
Adapted config for generating jar more conveniently.

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -8,7 +8,7 @@ Warbler::Config.new do |config|
   # - gemjar: package the gem repository in a jar file in WEB-INF/lib
   # - executable: embed a web server and make the war executable
   # - compiled: compile .rb files to .class files
-  config.features = %w(executable)
+  config.features = %w(executable compiled)
 
   # Application directories to be included in the webapp.
   #config.dirs = %w(audio/jump.wav, bofrev)
@@ -17,7 +17,7 @@ Warbler::Config.new do |config|
   #config.includes = FileList["bin/audio/jump.wav"]
 
   # Additional files/directories to exclude
-  # config.excludes = FileList["lib/tasks/*"]
+  config.excludes = FileList["test", "config"]
 
   # Additional Java .jar files to include.  Note that if .jar files are placed
   # in lib (and not otherwise excluded) then they need not be mentioned here.
@@ -41,7 +41,7 @@ Warbler::Config.new do |config|
   # project directory, it will be used to collect the gems to bundle
   # in your application. If you wish to explicitly disable this
   # functionality, uncomment here.
-  # config.bundler = false
+  config.bundler = false
 
   # An array of Bundler groups to avoid including in the war file.
   # Defaults to ["development", "test", "assets"].
@@ -111,7 +111,7 @@ Warbler::Config.new do |config|
   # config.override_gem_home = true
 
   # Allows for specifing custom executables
-  # config.executable = ["rake", "bin/rake"]
+  config.executable = "bofrev"
 
   # Sets default (prefixed) parameters for the executables
   # config.executable_params = "do:something"

--- a/make_jar
+++ b/make_jar
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
+require 'fileutils'
 
-system("mkdir bin")
-system("cp bofrev bin/bofrev")
-system("warble executable jar")
-system("rm -rf bin/")
+# Remove previously compiled file
+FileUtils.rm_f("bofrev.jar")
+
+# Generate executable
+system("warble jar")
+
 puts "Executable jar created."


### PR DESCRIPTION
Does now automatically compile .class of all rb files and solves therefore #51. Further, gems defined by bundler and bundler itself are not included anymore (these are only used for development anyway). This shrinks the size of the jar to half, which is still 20 mb since jruby needs to be included as library.

Also setting executable name in config instead of doing wanky stuff in config jar.

On Linux, the created jar does however not work, but the same goes for the jar created on master. I get the following behavior:

java -jar bofrev.jar -> game window opens for a split second, terminates and the execution finished. How does the jar generated on master/this branch behave for you @simplay ?
